### PR TITLE
Make the linked resource files protocol agnostic

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -8,8 +8,8 @@
     <meta name="HandheldFriendly" content="True" />
     <meta name="MobileOptimized" content="320" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href='http://fonts.googleapis.com/css?family=Lato:300,400,700,900,300italic,400italic,700italic' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Merriweather:400,300,700,400italic,300italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Lato:300,400,700,900,300italic,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Merriweather:400,300,700,400italic,300italic,700italic' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="/assets/css/screen.css" />
     {{ghost_head}}
 </head>
@@ -26,12 +26,12 @@
     <script type="text/javascript" src="/assets/js/jquery.js"></script>
     <script type="text/javascript" src="/assets/js/jquery.stellar.min.js"></script>
     <script type="text/javascript" src="/assets/js/index.js"></script>
-	<script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>
+	<script src="//google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>
     <script>
     $(document).ready(function(){
         $(window).stellar();
     })
     </script>
-	<link rel="stylesheet" href="http://jmblog.github.io/color-themes-for-google-code-prettify/css/themes/tomorrow.css">
+	<link rel="stylesheet" href="//jmblog.github.io/color-themes-for-google-code-prettify/css/themes/tomorrow.css">
 </body>
 </html>


### PR DESCRIPTION
The linked resource files such as CSS and JS would not load in the browser over SSL. I tested the theme over SSL connection using Chrome 34.0.1847.116 and got the following error in console.

![screenshot 2014-04-17 17 26 43](https://cloud.githubusercontent.com/assets/1987473/2738586/0fc1f31c-c691-11e3-926e-8d5f73af8ca0.png)

I removed the http:// protocol from all the external resources to fix the protocol dependency.

More info [here](http://www.paulirish.com/2010/the-protocol-relative-url/)
